### PR TITLE
Add Fody method timer instrumentation

### DIFF
--- a/ASPNETCoreWebApp.csproj
+++ b/ASPNETCoreWebApp.csproj
@@ -1,13 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="tests/**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fody" Version="6.9.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="MethodTimer.Fody" Version="3.2.3" />
   </ItemGroup>
 
 </Project>

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -1,9 +1,11 @@
 ﻿using ASPNETCoreWebApp.Models;
 using Microsoft.AspNetCore.Mvc;
 using System.Diagnostics;
+using MethodTimer;
 
 namespace ASPNETCoreWebApp.Controllers
 {
+    [Time]
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;

--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,0 +1,3 @@
+<Weavers>
+  <MethodTimer/>
+</Weavers>

--- a/MethodTimeLogger.cs
+++ b/MethodTimeLogger.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
+public static class MethodTimeLogger
+{
+    public static void Log(MethodBase methodBase, long milliseconds, string? message = null)
+    {
+        var name = methodBase.DeclaringType?.FullName + "." + methodBase.Name;
+        if (!string.IsNullOrEmpty(message))
+        {
+            Console.WriteLine($"{name} took {milliseconds}ms. {message}");
+        }
+        else
+        {
+            Console.WriteLine($"{name} took {milliseconds}ms.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update project to .NET 8
- add Fody and MethodTimer packages
- create `MethodTimeLogger` for logging
- weave methods using `[Time]` via Fody
- log HomeController timings

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686db5ec5d9083269d19617aa5b63324