### PR TITLE
Create GitBook-inspired documentation experience

### DIFF
--- a/Controllers/BooksController.cs
+++ b/Controllers/BooksController.cs
@@ -1,0 +1,64 @@
+using ASPNETCoreWebApp.Services;
+using ASPNETCoreWebApp.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ASPNETCoreWebApp.Controllers;
+
+[Route("books")]
+public class BooksController : Controller
+{
+    private readonly IDocumentationService _documentationService;
+
+    public BooksController(IDocumentationService documentationService)
+    {
+        _documentationService = documentationService;
+    }
+
+    [HttpGet]
+    public IActionResult Index()
+    {
+        var books = _documentationService.GetBooks();
+        return View(books);
+    }
+
+    [HttpGet("{bookSlug}")]
+    public IActionResult Book(string bookSlug)
+    {
+        var book = _documentationService.GetBookBySlug(bookSlug);
+        if (book is null)
+        {
+            return NotFound();
+        }
+
+        var orderedChapters = book.Chapters
+            .OrderBy(chapter => chapter.Order)
+            .ThenBy(chapter => chapter.Title)
+            .ToList();
+
+        var firstChapter = orderedChapters.FirstOrDefault();
+        var nextChapter = orderedChapters.Skip(1).FirstOrDefault();
+
+        var viewModel = new BookChapterViewModel(book, firstChapter, null, nextChapter);
+
+        return View("Chapter", viewModel);
+    }
+
+    [HttpGet("{bookSlug}/chapter/{chapterSlug}")]
+    public IActionResult Chapter(string bookSlug, string chapterSlug)
+    {
+        var book = _documentationService.GetBookBySlug(bookSlug);
+        if (book is null)
+        {
+            return NotFound();
+        }
+
+        var (chapter, previous, next) = _documentationService.GetChapterWithSiblings(bookSlug, chapterSlug);
+        if (chapter is null)
+        {
+            return RedirectToAction(nameof(Book), new { bookSlug });
+        }
+
+        var viewModel = new BookChapterViewModel(book, chapter, previous, next);
+        return View(viewModel);
+    }
+}

--- a/Models/Documentation/Book.cs
+++ b/Models/Documentation/Book.cs
@@ -1,0 +1,21 @@
+namespace ASPNETCoreWebApp.Models.Documentation;
+
+public class Book
+{
+    public string Title { get; init; } = string.Empty;
+
+    public string Slug { get; init; } = string.Empty;
+
+    public string Description { get; init; } = string.Empty;
+
+    public string Icon { get; init; } = string.Empty;
+
+    public string AccentColor { get; init; } = "#4F46E5";
+
+    public DateTimeOffset LastUpdated { get; init; }
+        = DateTimeOffset.UtcNow;
+
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
+
+    public IReadOnlyList<Chapter> Chapters { get; init; } = Array.Empty<Chapter>();
+}

--- a/Models/Documentation/Chapter.cs
+++ b/Models/Documentation/Chapter.cs
@@ -1,0 +1,19 @@
+namespace ASPNETCoreWebApp.Models.Documentation;
+
+public class Chapter
+{
+    public string Title { get; init; } = string.Empty;
+
+    public string Slug { get; init; } = string.Empty;
+
+    public string Summary { get; init; } = string.Empty;
+
+    public int Order { get; init; }
+        = 0;
+
+    public int EstimatedReadMinutes { get; init; }
+        = 5;
+
+    public IReadOnlyList<ChapterSection> Sections { get; init; }
+        = Array.Empty<ChapterSection>();
+}

--- a/Models/Documentation/ChapterSection.cs
+++ b/Models/Documentation/ChapterSection.cs
@@ -1,0 +1,23 @@
+namespace ASPNETCoreWebApp.Models.Documentation;
+
+public class ChapterSection
+{
+    public string Anchor { get; init; } = string.Empty;
+
+    public string Title { get; init; } = string.Empty;
+
+    public IReadOnlyList<string> Paragraphs { get; init; }
+        = Array.Empty<string>();
+
+    public IReadOnlyList<string>? KeyPoints { get; init; }
+        = Array.Empty<string>();
+
+    public string? CalloutTitle { get; init; }
+        = null;
+
+    public string? CalloutBody { get; init; }
+        = null;
+
+    public string CalloutTone { get; init; }
+        = "info";
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,10 @@
+using ASPNETCoreWebApp.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
+builder.Services.AddSingleton<IDocumentationService, DocumentationService>();
 
 var app = builder.Build();
 

--- a/Services/DocumentationService.cs
+++ b/Services/DocumentationService.cs
@@ -1,0 +1,332 @@
+using ASPNETCoreWebApp.Models.Documentation;
+using System.Collections.Immutable;
+
+namespace ASPNETCoreWebApp.Services;
+
+public class DocumentationService : IDocumentationService
+{
+    private readonly IReadOnlyList<Book> _books;
+
+    public DocumentationService()
+    {
+        _books = BuildLibrary();
+    }
+
+    public IReadOnlyList<Book> GetBooks() => _books;
+
+    public Book? GetBookBySlug(string slug)
+    {
+        return _books.FirstOrDefault(book =>
+            string.Equals(book.Slug, slug, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public Chapter? GetChapter(string bookSlug, string chapterSlug)
+    {
+        var (chapter, _, _) = GetChapterWithSiblings(bookSlug, chapterSlug);
+        return chapter;
+    }
+
+    public (Chapter? chapter, Chapter? previous, Chapter? next) GetChapterWithSiblings(string bookSlug, string chapterSlug)
+    {
+        var book = GetBookBySlug(bookSlug);
+        if (book is null)
+        {
+            return (null, null, null);
+        }
+
+        var orderedChapters = book.Chapters
+            .OrderBy(chapter => chapter.Order)
+            .ThenBy(chapter => chapter.Title)
+            .ToList();
+
+        var index = orderedChapters.FindIndex(chapter =>
+            string.Equals(chapter.Slug, chapterSlug, StringComparison.OrdinalIgnoreCase));
+
+        if (index < 0)
+        {
+            return (null, null, null);
+        }
+
+        var chapter = orderedChapters[index];
+        var previous = index > 0 ? orderedChapters[index - 1] : null;
+        var next = index < orderedChapters.Count - 1 ? orderedChapters[index + 1] : null;
+
+        return (chapter, previous, next);
+    }
+
+    private static IReadOnlyList<Book> BuildLibrary()
+    {
+        var productGuide = new Book
+        {
+            Title = "GitBook Lite — Product Guide",
+            Slug = "product-guide",
+            Description = "Everything you need to create, organize and publish beautiful documentation spaces.",
+            Icon = "🚀",
+            AccentColor = "#6366F1",
+            LastUpdated = new DateTimeOffset(2023, 9, 18, 0, 0, 0, TimeSpan.Zero),
+            Tags = new[] { "Getting started", "Authors", "Spaces" },
+            Chapters = new List<Chapter>
+            {
+                new()
+                {
+                    Title = "Welcome to your space",
+                    Slug = "welcome-to-your-space",
+                    Summary = "Understand how spaces, navigation and publishing work together in GitBook Lite.",
+                    Order = 1,
+                    EstimatedReadMinutes = 6,
+                    Sections = new List<ChapterSection>
+                    {
+                        new()
+                        {
+                            Anchor = "why-gitbook-lite",
+                            Title = "Why teams love GitBook",
+                            Paragraphs = new[]
+                            {
+                                "GitBook Lite reimagines documentation as a collaborative canvas. Organize knowledge in spaces, invite team members, and publish polished guides in minutes.",
+                                "Spaces keep everything structured. Pages, nested groups and callouts mirror the layout your readers expect without forcing you into a rigid tree." ,
+                            },
+                            KeyPoints = new[]
+                            {
+                                "Structure information with nested navigation and callouts.",
+                                "Publish updates instantly or schedule them for later.",
+                                "Invite reviewers with granular commenting access.",
+                            },
+                            CalloutTitle = "Tip",
+                            CalloutBody = "Start with a single space dedicated to your product. You can link to additional playbooks later without disrupting readers.",
+                            CalloutTone = "success",
+                        },
+                        new()
+                        {
+                            Anchor = "space-anatomy",
+                            Title = "Anatomy of a space",
+                            Paragraphs = new[]
+                            {
+                                "A space combines your navigation, content and publishing preferences. Drafts live alongside published pages, so contributors collaborate without risking the live version.",
+                                "Within each space you can define collections to group related documentation sets like onboarding, API references and troubleshooting." ,
+                            },
+                            KeyPoints = new[]
+                            {
+                                "Navigation groups order your chapters and sections.",
+                                "Collections allow multi-product organizations to reuse templates.",
+                                "Integrations connect spaces with Slack, Jira and the tools you already use.",
+                            },
+                        },
+                        new()
+                        {
+                            Anchor = "publishing-flow",
+                            Title = "Publishing flow",
+                            Paragraphs = new[]
+                            {
+                                "Every page keeps a draft and published state. Draft changes are private to editors until you publish them.",
+                                "Use review requests to loop in subject matter experts. Approvals are tracked directly on the page so the audit trail lives beside the content." ,
+                            },
+                            CalloutTitle = "Remember",
+                            CalloutBody = "Publishing pushes only the pages you approve. Drafts for other chapters stay untouched, making iterative updates simple.",
+                            CalloutTone = "info",
+                        },
+                    },
+                },
+                new()
+                {
+                    Title = "Authoring content",
+                    Slug = "authoring-content",
+                    Summary = "Master the editor, reusable blocks and collaboration tools.",
+                    Order = 2,
+                    EstimatedReadMinutes = 8,
+                    Sections = new List<ChapterSection>
+                    {
+                        new()
+                        {
+                            Anchor = "editor-essentials",
+                            Title = "Editor essentials",
+                            Paragraphs = new[]
+                            {
+                                "Compose pages with headings, callouts, tabs and embeds. Markdown shortcuts keep writers in flow while block menus surface advanced formatting.",
+                                "Drag and drop blocks to reorganize sections. Multi-select allows large structural updates without losing context." ,
+                            },
+                            KeyPoints = new[]
+                            {
+                                "Type '/' to open the block palette.",
+                                "Use nested callouts to highlight warnings or success states.",
+                            },
+                        },
+                        new()
+                        {
+                            Anchor = "collaboration",
+                            Title = "Collaboration",
+                            Paragraphs = new[]
+                            {
+                                "Comment on specific blocks to ask questions, request context or highlight wins.",
+                                "Mention teammates with @ to bring them into the conversation and assign tasks.",
+                            },
+                            CalloutTitle = "Pro tip",
+                            CalloutBody = "Enable change suggestions to allow reviewers to propose edits that you can accept with one click.",
+                            CalloutTone = "success",
+                        },
+                        new()
+                        {
+                            Anchor = "content-reuse",
+                            Title = "Reuse content",
+                            Paragraphs = new[]
+                            {
+                                "Save recurring snippets as reusable blocks. Marketing updates, release highlights or troubleshooting steps stay consistent across pages.",
+                                "Version content across spaces by syncing pages. GitBook keeps track of updates and suggests when linked spaces need a refresh.",
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    Title = "Publishing and analytics",
+                    Slug = "publishing-and-analytics",
+                    Summary = "Share documentation with the right audience and learn what resonates.",
+                    Order = 3,
+                    EstimatedReadMinutes = 7,
+                    Sections = new List<ChapterSection>
+                    {
+                        new()
+                        {
+                            Anchor = "share-controls",
+                            Title = "Share controls",
+                            Paragraphs = new[]
+                            {
+                                "Set your space visibility to public, private or invite-only. Share single pages with review links when you need quick feedback.",
+                                "Custom domains and themes keep your docs consistent with your brand, so public readers feel at home.",
+                            },
+                        },
+                        new()
+                        {
+                            Anchor = "insights",
+                            Title = "Insights and feedback",
+                            Paragraphs = new[]
+                            {
+                                "Track how readers navigate your documentation with built-in analytics. Identify chapters that spark questions and ship improvements fast.",
+                                "Collect emoji reactions and inline feedback so your team knows which topics deserve more attention.",
+                            },
+                            CalloutTitle = "Next steps",
+                            CalloutBody = "Connect your space with Slack or email to notify the team when readers leave feedback.",
+                            CalloutTone = "warning",
+                        },
+                    },
+                },
+            }
+        };
+
+        var onboardingPlaybook = new Book
+        {
+            Title = "Engineering Playbook",
+            Slug = "engineering-playbook",
+            Description = "A curated onboarding space for new engineers joining the team.",
+            Icon = "🧭",
+            AccentColor = "#10B981",
+            LastUpdated = new DateTimeOffset(2023, 10, 2, 0, 0, 0, TimeSpan.Zero),
+            Tags = new[] { "Onboarding", "Culture", "Best practices" },
+            Chapters = new List<Chapter>
+            {
+                new()
+                {
+                    Title = "Week 1 roadmap",
+                    Slug = "week-1-roadmap",
+                    Summary = "Set newcomers up for success with a clear schedule and goals.",
+                    Order = 1,
+                    EstimatedReadMinutes = 5,
+                    Sections = new List<ChapterSection>
+                    {
+                        new()
+                        {
+                            Anchor = "day-one",
+                            Title = "Day one essentials",
+                            Paragraphs = new[]
+                            {
+                                "Kick off with a welcome call, workspace setup and access provisioning. Pair new hires with a buddy who can answer questions quickly.",
+                                "Point engineers to the product guide so they can explore the platform from a reader's perspective.",
+                            },
+                            KeyPoints = new[]
+                            {
+                                "Provide system access before the first day.",
+                                "Share the product space as required reading.",
+                            },
+                        },
+                        new()
+                        {
+                            Anchor = "learning-plan",
+                            Title = "Craft a learning plan",
+                            Paragraphs = new[]
+                            {
+                                "Encourage engineers to journal their first week observations directly in GitBook Lite. Inline comments become a feedback loop for documentation gaps.",
+                                "Outline shadowing sessions, pair programming slots and product deep-dives so expectations stay clear.",
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    Title = "Ways of working",
+                    Slug = "ways-of-working",
+                    Summary = "Document rituals, code review etiquette and communication norms.",
+                    Order = 2,
+                    EstimatedReadMinutes = 6,
+                    Sections = new List<ChapterSection>
+                    {
+                        new()
+                        {
+                            Anchor = "rituals",
+                            Title = "Team rituals",
+                            Paragraphs = new[]
+                            {
+                                "Stand-ups happen asynchronously inside GitBook comments. Engineers post blockers and updates before 10am local time.",
+                                "Sprint reviews focus on outcomes. Embed loom videos, prototypes and doc links so stakeholders can catch up at their own pace.",
+                            },
+                        },
+                        new()
+                        {
+                            Anchor = "quality-bar",
+                            Title = "Quality bar",
+                            Paragraphs = new[]
+                            {
+                                "All pull requests include context, screenshots and links to the relevant documentation chapter.",
+                                "Use the troubleshooting chapter when customer issues arise. Leave reaction emojis when fixes are shipped to close the loop.",
+                            },
+                            CalloutTitle = "Team value",
+                            CalloutBody = "Docs are the source of truth. If a process changes, update the space before announcing it in chat.",
+                            CalloutTone = "info",
+                        },
+                    },
+                },
+                new()
+                {
+                    Title = "Tooling index",
+                    Slug = "tooling-index",
+                    Summary = "Quick links and onboarding tasks for the platforms we rely on daily.",
+                    Order = 3,
+                    EstimatedReadMinutes = 4,
+                    Sections = new List<ChapterSection>
+                    {
+                        new()
+                        {
+                            Anchor = "repositories",
+                            Title = "Repositories",
+                            Paragraphs = new[]
+                            {
+                                "Our code lives on GitHub. Bookmark the engineering playbook repository and subscribe to release notes.",
+                                "Use GitBook's Git sync integration if you prefer to draft long-form guides in your IDE.",
+                            },
+                        },
+                        new()
+                        {
+                            Anchor = "communications",
+                            Title = "Communication channels",
+                            Paragraphs = new[]
+                            {
+                                "Slack remains our heartbeat. Join #onboarding, #release-updates and your squad channel.",
+                                "We mirror major announcements inside GitBook so knowledge stays discoverable beyond the chat timeline.",
+                            },
+                        },
+                    },
+                },
+            }
+        };
+
+        return ImmutableList.Create(productGuide, onboardingPlaybook);
+    }
+}

--- a/Services/IDocumentationService.cs
+++ b/Services/IDocumentationService.cs
@@ -1,0 +1,14 @@
+using ASPNETCoreWebApp.Models.Documentation;
+
+namespace ASPNETCoreWebApp.Services;
+
+public interface IDocumentationService
+{
+    IReadOnlyList<Book> GetBooks();
+
+    Book? GetBookBySlug(string slug);
+
+    Chapter? GetChapter(string bookSlug, string chapterSlug);
+
+    (Chapter? chapter, Chapter? previous, Chapter? next) GetChapterWithSiblings(string bookSlug, string chapterSlug);
+}

--- a/ViewModels/BookChapterViewModel.cs
+++ b/ViewModels/BookChapterViewModel.cs
@@ -1,0 +1,28 @@
+using ASPNETCoreWebApp.Models.Documentation;
+
+namespace ASPNETCoreWebApp.ViewModels;
+
+public class BookChapterViewModel
+{
+    public BookChapterViewModel(Book book, Chapter? current, Chapter? previous, Chapter? next)
+    {
+        Book = book;
+        CurrentChapter = current;
+        PreviousChapter = previous;
+        NextChapter = next;
+    }
+
+    public Book Book { get; }
+
+    public Chapter? CurrentChapter { get; }
+
+    public Chapter? PreviousChapter { get; }
+
+    public Chapter? NextChapter { get; }
+
+    public bool IsActiveChapter(Chapter chapter)
+    {
+        return CurrentChapter is not null &&
+               string.Equals(CurrentChapter.Slug, chapter.Slug, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Views/Books/Chapter.cshtml
+++ b/Views/Books/Chapter.cshtml
@@ -1,0 +1,134 @@
+@model BookChapterViewModel
+@{
+    var chapter = Model.CurrentChapter;
+    ViewData["Title"] = chapter is null ? Model.Book.Title : $"{chapter.Title} · {Model.Book.Title}";
+    var sections = chapter?.Sections ?? Array.Empty<ChapterSection>();
+}
+
+<section class="doc-shell">
+    <button class="doc-nav-toggle" type="button" data-doc-toggle aria-controls="docSidebar" aria-expanded="false">
+        <span class="doc-nav-toggle__icon">☰</span>
+        Navigation
+    </button>
+    <aside class="doc-sidebar" id="docSidebar" data-doc-sidebar>
+        <div class="doc-sidebar__brand">
+            <div class="doc-sidebar__icon" style="background: @Model.Book.AccentColor">@Model.Book.Icon</div>
+            <div>
+                <p class="doc-sidebar__title">@Model.Book.Title</p>
+                <p class="doc-sidebar__description">@Model.Book.Description</p>
+            </div>
+        </div>
+        <nav class="doc-sidebar__nav" aria-label="Chapter navigation">
+            <ul>
+                @foreach (var entry in Model.Book.Chapters.OrderBy(c => c.Order).ThenBy(c => c.Title))
+                {
+                    <li class="@(Model.IsActiveChapter(entry) ? "is-active" : string.Empty)">
+                        <a asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="@Model.Book.Slug" asp-route-chapterSlug="@entry.Slug">
+                            <span>@entry.Title</span>
+                            <span class="doc-sidebar__summary">@entry.Summary</span>
+                        </a>
+                    </li>
+                }
+            </ul>
+        </nav>
+        <footer class="doc-sidebar__footer">
+            <p class="doc-sidebar__updated">Last updated <strong>@Model.Book.LastUpdated.ToString("MMMM d, yyyy")</strong></p>
+            <ul class="doc-sidebar__tags">
+                @foreach (var tag in Model.Book.Tags)
+                {
+                    <li>@tag</li>
+                }
+            </ul>
+        </footer>
+    </aside>
+
+    <article class="doc-article">
+        @if (chapter is null)
+        {
+            <header class="doc-header">
+                <h1>We're preparing this chapter</h1>
+                <p>Check back soon for fresh guidance. In the meantime, explore the other chapters in this space.</p>
+            </header>
+        }
+        else
+        {
+            <header class="doc-header">
+                <p class="eyebrow">@Model.Book.Title</p>
+                <h1>@chapter.Title</h1>
+                <p class="doc-header__summary">@chapter.Summary</p>
+                <div class="doc-header__meta">
+                    <span>@chapter.EstimatedReadMinutes min read</span>
+                </div>
+            </header>
+
+            <div class="doc-content">
+                @foreach (var section in sections)
+                {
+                    <section id="@section.Anchor" class="doc-section">
+                        <h2>@section.Title</h2>
+                        @foreach (var paragraph in section.Paragraphs)
+                        {
+                            <p>@paragraph</p>
+                        }
+
+                        @if (section.KeyPoints is not null && section.KeyPoints.Any())
+                        {
+                            <div class="doc-section__callout">
+                                <p class="doc-section__callout-title">Key takeaways</p>
+                                <ul>
+                                    @foreach (var point in section.KeyPoints)
+                                    {
+                                        <li>@point</li>
+                                    }
+                                </ul>
+                            </div>
+                        }
+
+                        @if (!string.IsNullOrWhiteSpace(section.CalloutBody))
+                        {
+                            <div class="doc-callout doc-callout--@section.CalloutTone">
+                                @if (!string.IsNullOrWhiteSpace(section.CalloutTitle))
+                                {
+                                    <h3>@section.CalloutTitle</h3>
+                                }
+                                <p>@section.CalloutBody</p>
+                            </div>
+                        }
+                    </section>
+                }
+            </div>
+
+            <nav class="doc-pagination" aria-label="Chapter pagination">
+                @if (Model.PreviousChapter is not null)
+                {
+                    <a class="doc-pagination__link doc-pagination__link--previous" asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="@Model.Book.Slug" asp-route-chapterSlug="@Model.PreviousChapter.Slug">
+                        <span class="label">Previous</span>
+                        <span class="title">@Model.PreviousChapter.Title</span>
+                    </a>
+                }
+                <span class="doc-pagination__spacer"></span>
+                @if (Model.NextChapter is not null)
+                {
+                    <a class="doc-pagination__link doc-pagination__link--next" asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="@Model.Book.Slug" asp-route-chapterSlug="@Model.NextChapter.Slug">
+                        <span class="label">Next</span>
+                        <span class="title">@Model.NextChapter.Title</span>
+                    </a>
+                }
+            </nav>
+        }
+    </article>
+
+    <aside class="doc-toc" aria-label="On this page">
+        <div class="doc-toc__inner">
+            <p class="doc-toc__title">On this page</p>
+            <ul>
+                @foreach (var section in sections)
+                {
+                    <li>
+                        <a href="#@section.Anchor">@section.Title</a>
+                    </li>
+                }
+            </ul>
+        </div>
+    </aside>
+</section>

--- a/Views/Books/Index.cshtml
+++ b/Views/Books/Index.cshtml
@@ -1,0 +1,111 @@
+@model IReadOnlyList<Book>
+@{
+    ViewData["Title"] = "Documentation library";
+    var featured = Model.FirstOrDefault();
+}
+
+<section class="library-hero">
+    <div class="library-hero__content">
+        <p class="eyebrow">Spaces</p>
+        <h1>All of your knowledge, beautifully organized</h1>
+        <p class="lead">
+            Explore a curated library of GitBook-style documentation spaces. Each space pairs intuitive navigation with
+            rich storytelling so your team can ship clarity, faster.
+        </p>
+        <div class="actions">
+            <a class="btn btn-primary" asp-controller="Books" asp-action="Index">Browse library</a>
+            @if (featured is not null && featured.Chapters.Any())
+            {
+                var firstChapter = featured.Chapters.OrderBy(c => c.Order).First();
+                <a class="btn btn-ghost" asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="@featured.Slug" asp-route-chapterSlug="@firstChapter.Slug">
+                    Jump into @firstChapter.Title
+                </a>
+            }
+        </div>
+        <ul class="metrics">
+            <li>
+                <strong>@Model.Sum(book => book.Chapters.Count)</strong>
+                <span>chapters of best-practice guidance</span>
+            </li>
+            <li>
+                <strong>@Model.Count</strong>
+                <span>spaces tailored for your team</span>
+            </li>
+            <li>
+                <strong>100%</strong>
+                <span>authored in a GitBook-inspired editor</span>
+            </li>
+        </ul>
+    </div>
+    <div class="library-hero__preview">
+        <div class="preview-card">
+            <div class="preview-card__header">
+                <span class="preview-icon">📚</span>
+                <span class="preview-label">Spaces overview</span>
+            </div>
+            <div class="preview-card__body">
+                <h3>@(featured?.Title ?? "Create gorgeous documentation")</h3>
+                <p>@(featured?.Description ?? "Bring your product, onboarding and team rituals together in one elegant experience.")</p>
+                <ul>
+                    <li>Responsive layout that mirrors GitBook navigation</li>
+                    <li>Sticky table of contents for effortless scanning</li>
+                    <li>Handcrafted sample content so you can move fast</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="book-grid">
+    <header>
+        <h2>Featured spaces</h2>
+        <p>Clone a space to kick-start your own documentation experience.</p>
+    </header>
+    <div class="book-grid__items">
+        @foreach (var book in Model)
+        {
+            var firstChapter = book.Chapters.OrderBy(chapter => chapter.Order).FirstOrDefault();
+            <article class="book-card" style="--book-accent: @book.AccentColor;">
+                <a asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="@book.Slug" asp-route-chapterSlug="@firstChapter?.Slug">
+                    <span class="book-card__icon" aria-hidden="true">@book.Icon</span>
+                    <div class="book-card__body">
+                        <div class="book-card__meta">
+                            <span class="tag">Updated @book.LastUpdated.ToString("MMMM yyyy")</span>
+                            <span class="tag">@book.Chapters.Count chapter@(book.Chapters.Count == 1 ? string.Empty : "s")</span>
+                        </div>
+                        <h3>@book.Title</h3>
+                        <p>@book.Description</p>
+                        <ul class="book-card__tags">
+                            @foreach (var tag in book.Tags)
+                            {
+                                <li>@tag</li>
+                            }
+                        </ul>
+                    </div>
+                    <span class="book-card__cta">Open space →</span>
+                </a>
+            </article>
+        }
+    </div>
+</section>
+
+<section class="value-props">
+    <header>
+        <h2>Designed for every part of the journey</h2>
+        <p>From onboarding to product launches, reuse the structure that GitBook popularized.</p>
+    </header>
+    <div class="value-props__grid">
+        <article>
+            <h3>Publish effortlessly</h3>
+            <p>Author collaboratively, keep drafts private, then publish updates with one click. Your readers always see the polished version.</p>
+        </article>
+        <article>
+            <h3>Guide readers with intent</h3>
+            <p>Sticky navigation, rich callouts and bulletproof hierarchies help readers stay oriented as they browse.</p>
+        </article>
+        <article>
+            <h3>Gather feedback in-line</h3>
+            <p>Collect comments and emoji reactions that map directly to the content they reference, just like GitBook.</p>
+        </article>
+    </div>
+</section>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -1,14 +1,94 @@
-﻿@{
-    ViewData["Title"] = "Home Page";
+@inject IDocumentationService Documentation
+@{
+    ViewData["Title"] = "A GitBook-inspired experience";
+    var spaces = Documentation.GetBooks();
+    var featuredSpace = spaces.FirstOrDefault();
+    var latestChapters = spaces
+        .SelectMany(book => book.Chapters.Select(chapter => (book, chapter)))
+        .OrderByDescending(tuple => tuple.book.LastUpdated)
+        .ThenBy(tuple => tuple.chapter.Order)
+        .Take(3)
+        .ToList();
 }
 
-<div class="text-center">
-    <h1 class="display-4">Welcome to code2cloud 3rd time</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
-    <label for="envSelect" class="form-label mt-3">Environment</label>
-    <select id="envSelect" class="form-select">
-        <option>Dev</option>
-        <option>QA</option>
-        <option>STG</option>
-    </select>
-</div>
+<section class="hero">
+    <div class="container hero__inner">
+        <div class="hero__content">
+            <p class="eyebrow">GitBook Lite</p>
+            <h1>Publish knowledge your team will adore</h1>
+            <p class="lead">Spin up spaces that look and feel like GitBook — complete with beautiful typography, sticky navigation and collaborative storytelling.</p>
+            <div class="actions">
+                <a class="btn btn-primary" asp-controller="Books" asp-action="Index">Explore spaces</a>
+                @if (featuredSpace is not null)
+                {
+                    var firstChapter = featuredSpace.Chapters.OrderBy(c => c.Order).FirstOrDefault();
+                    if (firstChapter is not null)
+                    {
+                        <a class="btn btn-ghost" asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="@featuredSpace.Slug" asp-route-chapterSlug="@firstChapter.Slug">Tour the product guide</a>
+                    }
+                }
+            </div>
+            <ul class="hero__stats">
+                <li><strong>@spaces.Count</strong><span>spaces ready to clone</span></li>
+                <li><strong>@spaces.Sum(space => space.Chapters.Count)</strong><span>chapters of curated best practices</span></li>
+                <li><strong>5 min</strong><span>to launch your first space</span></li>
+            </ul>
+        </div>
+        <div class="hero__preview">
+            <div class="preview-window">
+                <div class="preview-window__header">
+                    <span></span><span></span><span></span>
+                </div>
+                <div class="preview-window__body">
+                    <p class="preview-window__label">Spaces</p>
+                    <h3>@(featuredSpace?.Title ?? "Your next documentation hub")</h3>
+                    <p>@(featuredSpace?.Description ?? "Layer navigation, callouts and collaboration just like GitBook does.")</p>
+                    <ul>
+                        <li>Nested navigation with sticky context</li>
+                        <li>Callouts, tips and structured sections</li>
+                        <li>Accessible, responsive design</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="container highlights">
+    <header>
+        <h2>Why teams choose GitBook Lite</h2>
+        <p>We distilled the essence of GitBook into reusable building blocks for your .NET apps.</p>
+    </header>
+    <div class="highlights__grid">
+        <article>
+            <h3>Spaces as your knowledge OS</h3>
+            <p>Group related documentation into spaces so contributors stay focused and readers never get lost.</p>
+        </article>
+        <article>
+            <h3>Crafted storytelling</h3>
+            <p>Mix prose, checklists and callouts to guide readers. Every chapter ships with thoughtful defaults you can adapt in seconds.</p>
+        </article>
+        <article>
+            <h3>Actionable analytics</h3>
+            <p>Use the example insights chapter to understand how GitBook turns reader behavior into feedback loops.</p>
+        </article>
+    </div>
+</section>
+
+<section class="container latest">
+    <header>
+        <h2>Latest chapters</h2>
+        <p>A peek at the storytelling patterns included in each space.</p>
+    </header>
+    <div class="latest__grid">
+        @foreach (var (book, chapter) in latestChapters)
+        {
+            <article>
+                <span class="tag">@book.Title</span>
+                <h3>@chapter.Title</h3>
+                <p>@chapter.Summary</p>
+                <a asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="@book.Slug" asp-route-chapterSlug="@chapter.Slug">Read chapter →</a>
+            </article>
+        }
+    </div>
+</section>

--- a/Views/Home/Privacy.cshtml
+++ b/Views/Home/Privacy.cshtml
@@ -1,6 +1,14 @@
-﻿@{
-    ViewData["Title"] = "Privacy Policy";
+@{
+    ViewData["Title"] = "Privacy";
 }
-<h1>@ViewData["Title"]</h1>
 
-<p>Use this page to detail your site's privacy policy.</p>
+<section class="container legal">
+    <header>
+        <h1>Privacy &amp; trust</h1>
+        <p>GitBook Lite is a demo experience. No personal data is collected or stored.</p>
+    </header>
+    <div class="legal__content">
+        <p>Everything you see here runs locally in your environment. Feel free to extend the project with your own authentication, data collection policies or integrations. Until you do, nothing leaves your machine.</p>
+        <p>If you adapt GitBook Lite for production, remember to draft a privacy policy that reflects your actual data practices. GitBook provides great inspiration for transparency: outline what you collect, why you collect it, and how readers can request changes or deletion.</p>
+    </div>
+</section>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -1,46 +1,70 @@
-﻿<!DOCTYPE html>
+@inject IDocumentationService Documentation
+@{
+    var primarySpace = Documentation.GetBookBySlug("product-guide") ?? Documentation.GetBooks().FirstOrDefault();
+    var primaryChapter = primarySpace?.Chapters.OrderBy(c => c.Order).FirstOrDefault();
+    var primarySlug = primarySpace?.Slug;
+    var primaryChapterSlug = primaryChapter?.Slug;
+}
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - ASPNETCoreWebApp</title>
+    <title>@ViewData["Title"] - GitBook Lite</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/ASPNETCoreWebApp.styles.css" asp-append-version="true" />
 </head>
 <body>
-    <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
-            <div class="container-fluid">
-                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">ASPNETCoreWebApp</a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
-                        aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
-                    <ul class="navbar-nav flex-grow-1">
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
-                        </li>
-                    </ul>
-                </div>
+    <header class="topbar">
+        <div class="container">
+            <a class="topbar__brand" asp-controller="Home" asp-action="Index">GitBook Lite</a>
+            <nav class="topbar__nav" aria-label="Primary navigation">
+                <a asp-controller="Home" asp-action="Index">Home</a>
+                <a asp-controller="Books" asp-action="Index">Spaces</a>
+                @if (primarySlug is not null && primaryChapterSlug is not null)
+                {
+                    <a asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="@primarySlug" asp-route-chapterSlug="@primaryChapterSlug">Product guide</a>
+                }
+                <a asp-controller="Home" asp-action="Privacy">Privacy</a>
+            </nav>
+            <div class="topbar__cta">
+                @if (primarySlug is not null && primaryChapterSlug is not null)
+                {
+                    <a class="btn btn-primary" asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="@primarySlug" asp-route-chapterSlug="@primaryChapterSlug">Start reading</a>
+                }
+                else
+                {
+                    <a class="btn btn-primary" asp-controller="Books" asp-action="Index">Start reading</a>
+                }
             </div>
-        </nav>
+        </div>
     </header>
-    <div class="container">
-        <main role="main" class="pb-3">
+
+    <div class="page-shell">
+        <main class="page-content" role="main">
             @RenderBody()
         </main>
     </div>
 
-    <footer class="border-top footer text-muted">
+    <footer class="site-footer">
         <div class="container">
-            &copy; @DateTime.Now.Year - ASPNETCoreWebApp - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+            <div>
+                <span class="site-footer__brand">GitBook Lite</span>
+                <p>Build a calm, modern documentation experience inspired by GitBook.</p>
+            </div>
+            <nav aria-label="Footer">
+                <a asp-controller="Books" asp-action="Index">Spaces</a>
+                <a asp-controller="Books" asp-action="Chapter" asp-route-bookSlug="product-guide" asp-route-chapterSlug="welcome-to-your-space">Product guide</a>
+                <a asp-controller="Home" asp-action="Privacy">Privacy</a>
+            </nav>
+            <p class="site-footer__meta">&copy; @DateTime.Now.Year GitBook Lite — Crafted for demo purposes.</p>
         </div>
     </footer>
+
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>

--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,3 +1,7 @@
-﻿@using ASPNETCoreWebApp
+@using System.Linq
+@using ASPNETCoreWebApp
 @using ASPNETCoreWebApp.Models
+@using ASPNETCoreWebApp.Models.Documentation
+@using ASPNETCoreWebApp.Services
+@using ASPNETCoreWebApp.ViewModels
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/tests/ASPNETCoreWebApp.Tests/BooksControllerTests.cs
+++ b/tests/ASPNETCoreWebApp.Tests/BooksControllerTests.cs
@@ -1,0 +1,79 @@
+using ASPNETCoreWebApp.Controllers;
+using ASPNETCoreWebApp.Models.Documentation;
+using ASPNETCoreWebApp.Services;
+using ASPNETCoreWebApp.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace ASPNETCoreWebApp.Tests;
+
+public class BooksControllerTests
+{
+    [Fact]
+    public void Index_ReturnsBooksFromService()
+    {
+        var books = new List<Book>
+        {
+            new()
+            {
+                Title = "Sample",
+                Slug = "sample",
+                Chapters = new List<Chapter>()
+            }
+        };
+        var service = new Mock<IDocumentationService>();
+        service.Setup(s => s.GetBooks()).Returns(books);
+        var controller = new BooksController(service.Object);
+
+        var result = controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        Assert.Same(books, viewResult.Model);
+    }
+
+    [Fact]
+    public void Chapter_InvalidBook_ReturnsNotFound()
+    {
+        var service = new Mock<IDocumentationService>();
+        service.Setup(s => s.GetBookBySlug(It.IsAny<string>())).Returns((Book?)null);
+        var controller = new BooksController(service.Object);
+
+        var result = controller.Chapter("unknown", "chapter");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public void Chapter_ValidRequest_ReturnsViewWithViewModel()
+    {
+        var book = new Book
+        {
+            Title = "Demo",
+            Slug = "demo",
+            Chapters = new List<Chapter>
+            {
+                new()
+                {
+                    Title = "Intro",
+                    Slug = "intro",
+                    Order = 1,
+                    Sections = new List<ChapterSection>()
+                }
+            }
+        };
+
+        var service = new Mock<IDocumentationService>();
+        service.Setup(s => s.GetBookBySlug("demo")).Returns(book);
+        service.Setup(s => s.GetChapterWithSiblings("demo", "intro"))
+            .Returns((book.Chapters[0], null, null));
+
+        var controller = new BooksController(service.Object);
+
+        var result = controller.Chapter("demo", "intro");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var viewModel = Assert.IsType<BookChapterViewModel>(viewResult.Model);
+        Assert.Equal(book, viewModel.Book);
+        Assert.Equal("intro", viewModel.CurrentChapter?.Slug);
+    }
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1,22 +1,820 @@
-html {
-  font-size: 14px;
+:root {
+  color-scheme: light;
+  --color-surface: #f8fafc;
+  --color-surface-elevated: #ffffff;
+  --color-border: #e2e8f0;
+  --color-border-strong: #cbd5f5;
+  --color-primary: #6366f1;
+  --color-primary-dark: #4f46e5;
+  --color-text: #0f172a;
+  --color-text-muted: #475569;
+  --color-text-subtle: #64748b;
+  --color-highlight: #f1f5f9;
 }
 
-@media (min-width: 768px) {
-  html {
-    font-size: 16px;
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--color-surface);
+  color: var(--color-text);
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  padding: 0.65rem 1.4rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 10px 25px -15px rgba(79, 70, 229, 0.9);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background: var(--color-primary-dark);
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.btn-ghost {
+  border-color: var(--color-border);
+  color: var(--color-text);
+  background: transparent;
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  margin-bottom: 0.75rem;
+}
+
+.lead {
+  font-size: 1.15rem;
+  color: var(--color-text-muted);
+  margin-bottom: 1.5rem;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(248, 250, 252, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.topbar > .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1rem 1.5rem;
+}
+
+.topbar__brand {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.topbar__nav {
+  display: flex;
+  gap: 1.25rem;
+  font-weight: 500;
+  color: var(--color-text-subtle);
+}
+
+.topbar__nav a {
+  padding: 0.25rem 0;
+}
+
+.topbar__nav a:hover,
+.topbar__nav a:focus {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.page-shell {
+  padding: 3rem 0 5rem;
+}
+
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.hero {
+  padding: 4rem 0 3rem;
+}
+
+.hero__inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 480px);
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero__content h1 {
+  font-size: clamp(2rem, 3.2vw + 1rem, 3.25rem);
+  line-height: 1.05;
+  margin-bottom: 1.25rem;
+}
+
+.hero__content .actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.hero__stats {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  color: var(--color-text-subtle);
+}
+
+.hero__stats strong {
+  display: block;
+  font-size: 1.75rem;
+  color: var(--color-text);
+}
+
+.hero__preview {
+  display: flex;
+  justify-content: center;
+}
+
+.preview-window {
+  background: var(--color-surface-elevated);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 30px 70px -40px rgba(15, 23, 42, 0.45);
+  width: 100%;
+  padding: 1.5rem;
+}
+
+.preview-window__header {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.preview-window__header span {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: var(--color-border);
+}
+
+.preview-window__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--color-text-subtle);
+}
+
+.preview-window__body h3 {
+  font-size: 1.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.preview-window__body p {
+  color: var(--color-text-muted);
+}
+
+.preview-window__body ul {
+  margin: 1.25rem 0 0;
+  padding: 0 0 0 1.1rem;
+  color: var(--color-text-subtle);
+}
+
+.highlights {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.highlights__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.highlights__grid article {
+  background: var(--color-surface-elevated);
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 20px 40px -35px rgba(15, 23, 42, 0.35);
+}
+
+.highlights__grid h3 {
+  margin-bottom: 0.75rem;
+}
+
+.latest {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.latest__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.latest__grid article {
+  background: var(--color-surface-elevated);
+  border-radius: 1.25rem;
+  border: 1px solid var(--color-border);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: var(--color-highlight);
+  color: var(--color-text-subtle);
+  padding: 0.3rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.legal {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.legal h1 {
+  margin-bottom: 0.5rem;
+}
+
+.legal__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: var(--color-text-muted);
+  line-height: 1.75;
+}
+
+.library-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 3rem;
+  align-items: stretch;
+}
+
+.library-hero__content h1 {
+  font-size: clamp(2.2rem, 3.3vw + 1rem, 3.5rem);
+  margin-bottom: 1.25rem;
+}
+
+.library-hero__content .actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+.metrics {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  color: var(--color-text-subtle);
+}
+
+.metrics strong {
+  display: block;
+  font-size: 1.6rem;
+  color: var(--color-text);
+}
+
+.library-hero__preview {
+  display: flex;
+  align-items: center;
+}
+
+.preview-card {
+  background: var(--color-surface-elevated);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  padding: 2rem;
+  box-shadow: 0 35px 50px -40px rgba(79, 70, 229, 0.55);
+  width: 100%;
+}
+
+.preview-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-subtle);
+  margin-bottom: 1rem;
+}
+
+.preview-card__icon {
+  font-size: 1.35rem;
+}
+
+.preview-card__body ul {
+  margin: 1.25rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--color-text-subtle);
+}
+
+.book-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.book-grid__items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.75rem;
+}
+
+.book-card {
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  box-shadow: 0 25px 60px -45px rgba(79, 70, 229, 0.45);
+}
+
+.book-card > a {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  padding: 1.75rem;
+  height: 100%;
+}
+
+.book-card__icon {
+  font-size: 2rem;
+}
+
+.book-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: var(--color-text-subtle);
+}
+
+.book-card__tags {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.book-card__tags li {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  color: var(--color-primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.book-card__cta {
+  margin-top: auto;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.value-props {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.value-props__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.value-props__grid article {
+  background: var(--color-surface-elevated);
+  border-radius: 1.25rem;
+  border: 1px solid var(--color-border);
+  padding: 1.5rem;
+}
+
+.doc-shell {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 220px;
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.doc-nav-toggle {
+  display: none;
+}
+
+.doc-sidebar {
+  background: var(--color-surface-elevated);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  padding: 1.75rem;
+  position: sticky;
+  top: 6rem;
+  max-height: calc(100vh - 7rem);
+  overflow-y: auto;
+}
+
+.doc-sidebar__brand {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.doc-sidebar__icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.9rem;
+  display: grid;
+  place-items: center;
+  font-size: 1.35rem;
+  color: #fff;
+}
+
+.doc-sidebar__title {
+  font-weight: 600;
+}
+
+.doc-sidebar__description {
+  color: var(--color-text-subtle);
+  margin: 0.25rem 0 0;
+}
+
+.doc-sidebar__nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.doc-sidebar__nav a {
+  display: block;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.85rem;
+  color: var(--color-text-subtle);
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.doc-sidebar__nav a span:first-child {
+  display: block;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.doc-sidebar__summary {
+  display: block;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+  color: var(--color-text-subtle);
+}
+
+.doc-sidebar__nav li.is-active a,
+.doc-sidebar__nav a:hover,
+.doc-sidebar__nav a:focus {
+  background: rgba(99, 102, 241, 0.08);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.doc-sidebar__footer {
+  margin-top: 2rem;
+  color: var(--color-text-subtle);
+  font-size: 0.85rem;
+}
+
+.doc-sidebar__tags {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.doc-sidebar__tags li {
+  border-radius: 999px;
+  background: var(--color-highlight);
+  padding: 0.3rem 0.75rem;
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.doc-article {
+  background: var(--color-surface-elevated);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  padding: 2.5rem;
+  box-shadow: 0 40px 65px -50px rgba(15, 23, 42, 0.5);
+}
+
+.doc-header h1 {
+  font-size: clamp(2rem, 2.5vw + 1rem, 2.9rem);
+  margin-bottom: 1rem;
+}
+
+.doc-header__summary {
+  font-size: 1.05rem;
+  color: var(--color-text-muted);
+}
+
+.doc-header__meta {
+  display: flex;
+  gap: 1rem;
+  color: var(--color-text-subtle);
+  margin-top: 1rem;
+}
+
+.doc-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  margin-top: 2.5rem;
+}
+
+.doc-section h2 {
+  font-size: 1.6rem;
+  margin-bottom: 1rem;
+}
+
+.doc-section p {
+  color: var(--color-text-muted);
+  line-height: 1.7;
+}
+
+.doc-section__callout {
+  margin-top: 1.5rem;
+  background: var(--color-highlight);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.doc-section__callout-title {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.doc-callout {
+  margin-top: 1.5rem;
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid transparent;
+}
+
+.doc-callout--info {
+  background: #eef2ff;
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.doc-callout--success {
+  background: #ecfdf5;
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.doc-callout--warning {
+  background: #fff7ed;
+  border-color: rgba(249, 115, 22, 0.35);
+}
+
+.doc-pagination {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+  margin-top: 3rem;
+}
+
+.doc-pagination__link {
+  flex: 1;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: var(--color-highlight);
+  text-decoration: none;
+  color: var(--color-text);
+}
+
+.doc-pagination__link .label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--color-text-subtle);
+}
+
+.doc-pagination__link .title {
+  font-weight: 600;
+}
+
+.doc-pagination__link:hover,
+.doc-pagination__link:focus {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.doc-pagination__spacer {
+  width: 1px;
+}
+
+.doc-toc {
+  position: sticky;
+  top: 6rem;
+  align-self: start;
+}
+
+.doc-toc__inner {
+  position: sticky;
+  top: 6rem;
+  background: transparent;
+}
+
+.doc-toc__title {
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-text-subtle);
+}
+
+.doc-toc ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-text-subtle);
+}
+
+.site-footer {
+  background: #0f172a;
+  color: rgba(226, 232, 240, 0.9);
+  padding: 3rem 0;
+}
+
+.site-footer > .container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.site-footer__brand {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.site-footer nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.site-footer nav a {
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.site-footer__meta {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+@media (max-width: 1024px) {
+  .hero__inner,
+  .library-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .doc-shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .doc-sidebar {
+    position: fixed;
+    inset: 0;
+    z-index: 90;
+    max-height: none;
+    border-radius: 0;
+    transform: translateX(-110%);
+    transition: transform 0.25s ease;
+  }
+
+  .doc-sidebar.is-open {
+    transform: translateX(0);
+  }
+
+  .doc-nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-elevated);
+    position: sticky;
+    top: 5rem;
+    left: 1.5rem;
+    z-index: 95;
+    box-shadow: 0 10px 30px -20px rgba(15, 23, 42, 0.45);
+  }
+
+  .doc-toc {
+    display: none;
   }
 }
 
-.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
-}
+@media (max-width: 768px) {
+  .topbar > .container {
+    flex-wrap: wrap;
+  }
 
-html {
-  position: relative;
-  min-height: 100%;
-}
+  .hero {
+    padding-top: 3rem;
+  }
 
-body {
-  margin-bottom: 60px;
+  .hero__stats,
+  .metrics {
+    gap: 1.25rem;
+  }
+
+  .page-shell {
+    padding: 2.5rem 0 3rem;
+  }
+
+  .doc-article {
+    padding: 2rem 1.5rem;
+  }
 }

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,4 +1,37 @@
-﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
-// for details on configuring this project to bundle and minify static web assets.
+document.addEventListener("DOMContentLoaded", () => {
+    const toggle = document.querySelector('[data-doc-toggle]');
+    const sidebar = document.querySelector('[data-doc-sidebar]');
 
-// Write your JavaScript code.
+    if (!toggle || !sidebar) {
+        return;
+    }
+
+    const closeSidebar = () => {
+        sidebar.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded', 'false');
+        document.body.style.overflow = '';
+    };
+
+    const openSidebar = () => {
+        sidebar.classList.add('is-open');
+        toggle.setAttribute('aria-expanded', 'true');
+        document.body.style.overflow = 'hidden';
+    };
+
+    toggle.addEventListener('click', () => {
+        const isOpen = sidebar.classList.contains('is-open');
+        if (isOpen) {
+            closeSidebar();
+        } else {
+            openSidebar();
+        }
+    });
+
+    sidebar.querySelectorAll('a').forEach(link => {
+        link.addEventListener('click', () => {
+            if (window.innerWidth <= 1024) {
+                closeSidebar();
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- introduce documentation domain models and a data service seeded with sample GitBook-style spaces
- add a books controller and Razor pages that render a GitBook-inspired documentation experience
- refresh the global layout, landing page, styling and scripts to deliver the new navigation and responsive design
- cover the new controller with unit tests

## Testing
- `dotnet build` *(fails: dotnet CLI is unavailable in the execution environment)*
- `dotnet test` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce72be47348326b027caf46be1aca2